### PR TITLE
fix: use real photo from test artifacts in component interaction test

### DIFF
--- a/tests/system_integration_test.py
+++ b/tests/system_integration_test.py
@@ -294,13 +294,14 @@ def test_component_interaction():
         print("1️⃣  Testing MediaDetector + MediaValidator...")
         total_tests += 1
 
-        # Create a small test file
-        test_dir = Path(tempfile.mkdtemp(prefix="interaction_test_"))
-        test_file = test_dir / "test.jpg"
-        with open(test_file, 'wb') as f:
-            f.write(b'\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x01\x00H\x00H\x00\x00')
-            f.write(b'Test image data' * 10)
-            f.write(b'\xFF\xD9')
+        # Use real photo from test artifacts for validation
+        test_artifacts_dir = Path(__file__).parent / "artifacts" / "photos"
+        test_file = test_artifacts_dir / "Woman_Photo_1.jpeg"
+
+        # Verify the test photo exists
+        if not test_file.exists():
+            print(f"      ❌ Test photo not found: {test_file}")
+            test_file = test_artifacts_dir / "no_faces_photo1.jpg"  # Fallback
 
         from src.media_detector import MediaDetector
         from src.media_validator import MediaValidator
@@ -326,9 +327,6 @@ def test_component_interaction():
             success_count += 1
         else:
             print(f"      ❌ Validation failed: {result.get_summary()}")
-
-        # Cleanup
-        shutil.rmtree(test_dir)
 
         # Test 2: TemporalClusterer + EventNamer integration
         print("2️⃣  Testing TemporalClusterer + EventNamer...")


### PR DESCRIPTION
## Summary
Fixed component interaction test to use real photo from test artifacts instead of creating fake JPEG data, resolving MediaValidator false negative.

## Changes
- **Replaced fake JPEG creation** with real Woman_Photo_1.jpeg from test artifacts
- **Removed temp directory cleanup** since using existing artifacts
- **Added fallback logic** to no_faces_photo1.jpg if Woman photo not found

## Test Results
- **Before**: 3/4 component tests passing (MediaValidator reporting corrupted JPEG)
- **After**: ✅ **4/4 component tests passing** 
  - ✅ MediaDetector + MediaValidator integration
  - ✅ TemporalClusterer + EventNamer integration  
  - ✅ Configuration system integration
  - ✅ Error propagation handling

## Root Cause
MediaValidator was correctly identifying artificially created JPEG as invalid. Using real photo ensures proper validation testing.

## Closes
Fixes #7

## Test plan
- [x] Component interaction test passes (4/4 sub-tests)
- [x] Uses real photo from test artifacts
- [x] MediaValidator properly validates real JPEG
- [x] No regression in other component tests