### PR TITLE
fix: update MIN_CLUSTER_SIZE from 3 to 1 for consistency - fixes issue #27

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -28,7 +28,7 @@ FILENAME_PATTERN = r"IMG_(\d{8})_(\d{6})(?:_\d+)?\.(JPG|MOV|PNG|jpg|mov|png)$"
 # Clustering parameters
 TIME_THRESHOLD_HOURS = 6  # Group photos within 6 hours
 LOCATION_THRESHOLD_KM = 1.0  # Group photos within 1km
-MIN_CLUSTER_SIZE = 3  # Minimum photos for an event
+MIN_CLUSTER_SIZE = 1  # Minimum photos for an event (allow single-photo events)
 
 # GPU settings
 USE_GPU = True  # Enable GPU if available


### PR DESCRIPTION
## Summary
Fixes Issue #27 - Configuration inconsistency where `src/config.py` had `MIN_CLUSTER_SIZE = 3` but all other modules default to `min_cluster_size = 1`.

## Problem
This inconsistency could cause:
- Unpredictable filtering behavior across different modules
- Some modules allowing single-photo events while others filter them out
- Confusion for users about minimum event size requirements

## Change
Updated `src/config.py` line 31:
```python
# Before
MIN_CLUSTER_SIZE = 3  # Minimum photos for an event

# After
MIN_CLUSTER_SIZE = 1  # Minimum photos for an event (allow single-photo events)
```

## Verification
All modules now consistently use `min_cluster_size = 1`:
- ✅ `src/config.py` - MIN_CLUSTER_SIZE = 1
- ✅ `src/config_manager.py` - min_cluster_size: int = 1
- ✅ `src/temporal_clustering.py` - min_cluster_size: int = 1
- ✅ `src/media_clustering.py` - min_cluster_size: int = 1

Note: `people_database.py` uses `min_cluster_size: int = 2` which is correct - it's for face clustering, a different use case.

## Tests
✅ All basic tests pass (`test_media_detection`, `test_metadata_extraction`, `test_basic_gpu`)

## Context
This completes the work from todo.txt line 107:
> [x] Fix minimum cluster size filtering issues (changed from 3 to 1)

The change to 1 was intentional to allow single-photo events to be organized.

## Closes
Fixes #27