### PR TITLE
fix: correct EXIF orientation before face detection - addresses issue #53

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ transformers>=4.20.0,<4.48.0
 numpy>=1.21.0,<2.0.0
 pytest>=7.0.0
 python-dotenv>=1.0.0
+piexif>=1.1.0
 
 # Optional packages (require additional setup)
 # Install first: brew install cmake && brew install dlib

--- a/src/event_namer.py
+++ b/src/event_namer.py
@@ -258,13 +258,12 @@ class EventNamer:
         - Notice how we try multiple approaches in order of sophistication
         - Each approach has fallbacks for when data isn't available
         """
-        print(f"🎯 EVENT NAMING: Starting event name generation for cluster with {len(cluster_data.get('files', []))} files")
+        # Get files from either key (cluster_data uses 'media_files')
+        files = cluster_data.get('files', []) or cluster_data.get('media_files', [])
+        print(f"🎯 EVENT NAMING: Starting event name generation for cluster with {len(files)} files")
 
         # Create detailed diagnostic log
         self._log_diagnostics("=== EVENT NAMING DIAGNOSTICS START ===")
-
-        # Log file information clearly
-        files = cluster_data.get('files', []) or cluster_data.get('media_files', [])
         self._log_diagnostics(f"Cluster size: {len(files)} files")
 
         if files:


### PR DESCRIPTION
## Summary

- Fix face detection failing on iPhone photos due to EXIF orientation tags not being handled
- Add `_load_image_with_orientation()` method to FaceRecognizer that corrects orientation before detection
- Fix "0 files" display bug in EventNamer
- Add piexif to requirements for EXIF manipulation in tests

## Root Cause

`face_recognition.load_image_file()` doesn't handle EXIF orientation tags. iPhone photos with orientation tag 6 (90° CW rotation) were being processed without correction, causing the HOG face detector to see sideways faces and fail to detect them.

## Changes

| File | Change |
|------|--------|
| `src/face_recognizer.py` | Add `_load_image_with_orientation()` method handling all 8 EXIF orientation values |
| `src/event_namer.py` | Fix "0 files" display by checking both 'files' and 'media_files' keys |
| `requirements.txt` | Add piexif>=1.1.0 |
| `tests/integration/test_clustering_face_integration.py` | Add EXIF and rotation tests |

## Test Results

- `IMG_20160123_115549.JPG`: 0 faces → 1 face detected
- Sasha Strogan correctly identified
- All 41 tests pass

## Closes

Fixes #53

## Test plan

- [x] EXIF orientation test passes (simulates iPhone orientation 6)
- [x] Random pixel rotation test passes (robustness check)
- [x] All existing face recognition tests pass
- [x] All unit and integration tests pass (41 total)