### PR TITLE
fix: correct EXIF orientation before face detection - addresses issue #53

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ transformers>=4.20.0,<4.48.0
 numpy>=1.21.0,<2.0.0
 pytest>=7.0.0
 python-dotenv>=1.0.0
+piexif>=1.1.0
 
 # Optional packages (require additional setup)
 # Install first: brew install cmake && brew install dlib

--- a/src/event_namer.py
+++ b/src/event_namer.py
@@ -258,13 +258,12 @@ class EventNamer:
         - Notice how we try multiple approaches in order of sophistication
         - Each approach has fallbacks for when data isn't available
         """
-        print(f"🎯 EVENT NAMING: Starting event name generation for cluster with {len(cluster_data.get('files', []))} files")
+        # Get files from either key (cluster_data uses 'media_files')
+        files = cluster_data.get('files', []) or cluster_data.get('media_files', [])
+        print(f"🎯 EVENT NAMING: Starting event name generation for cluster with {len(files)} files")
 
         # Create detailed diagnostic log
         self._log_diagnostics("=== EVENT NAMING DIAGNOSTICS START ===")
-
-        # Log file information clearly
-        files = cluster_data.get('files', []) or cluster_data.get('media_files', [])
         self._log_diagnostics(f"Cluster size: {len(files)} files")
 
         if files:


### PR DESCRIPTION
## Summary
- Add EXIF orientation correction when loading images for face detection
- iPhone photos store rotation in EXIF metadata rather than rotating pixels
- face_recognition library doesn't handle this, causing face detection failures

## Changes
- Added `_load_image_with_orientation()` method to FaceRecognizer
- Handles all 8 EXIF orientation values
- Added comprehensive tests for EXIF and pixel rotation scenarios
- Fixed "0 files" display bug in event_namer.py

## Closes
Fixes #53

## Test plan
- [x] All 41 tests pass
- [x] EXIF orientation test validates orientation 6 handling
- [x] Random rotation test validates robustness